### PR TITLE
refactor: String 타입 token을 Device 객체로 변경

### DIFF
--- a/src/main/java/online/bottler/notification/adapter/out/persistence/EmbeddedDevice.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/EmbeddedDevice.java
@@ -1,0 +1,21 @@
+package online.bottler.notification.adapter.out.persistence;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import online.bottler.notification.domain.Device;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmbeddedDevice {
+
+    private String token;
+
+    public EmbeddedDevice(Device device) {
+        this.token = device.getToken();
+    }
+
+    public Device toDomain() {
+        return new Device(token);
+    }
+}

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
@@ -1,10 +1,6 @@
 package online.bottler.notification.adapter.out.persistence;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,13 +19,14 @@ public class SubscriptionEntity {
 
     private Long userId;
 
-    private String token;
+    @Embedded
+    private EmbeddedDevice device;
 
     public static SubscriptionEntity from(Subscription subscription) {
         return SubscriptionEntity.builder()
                 .id(subscription.getId())
                 .userId(subscription.getUserId())
-                .token(subscription.getToken())
+                .device(new EmbeddedDevice(subscription.getDevice()))
                 .build();
     }
 
@@ -37,7 +34,7 @@ public class SubscriptionEntity {
         return Subscription.builder()
                 .id(id)
                 .userId(userId)
-                .token(token)
+                .device(device.toDomain())
                 .build();
     }
 }

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
@@ -20,6 +20,9 @@ public class SubscriptionEntity {
     private Long userId;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "token", column = @Column(name = "token"))
+    })
     private EmbeddedDevice device;
 
     public static SubscriptionEntity from(Subscription subscription) {

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionJpaRepository.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionJpaRepository.java
@@ -8,7 +8,7 @@ public interface SubscriptionJpaRepository extends JpaRepository<SubscriptionEnt
 
     void deleteAllByUserId(Long userId);
 
-    void deleteByToken(String token);
+    void deleteByDevice(EmbeddedDevice device);
 
-    Boolean existsByUserIdAndToken(Long userId, String token);
+    Boolean existsByDevice(EmbeddedDevice device);
 }

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapter.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapter.java
@@ -2,6 +2,7 @@ package online.bottler.notification.adapter.out.persistence;
 
 import lombok.RequiredArgsConstructor;
 import online.bottler.notification.application.port.SubscriptionPersistencePort;
+import online.bottler.notification.domain.Device;
 import online.bottler.notification.domain.Subscription;
 import online.bottler.notification.domain.Subscriptions;
 import org.springframework.stereotype.Repository;
@@ -41,12 +42,12 @@ public class SubscriptionPersistenceAdapter implements SubscriptionPersistencePo
     }
 
     @Override
-    public void deleteByToken(String token) {
-        repository.deleteByToken(token);
+    public void deleteByDevice(Device device) {
+        repository.deleteByDevice(new EmbeddedDevice(device));
     }
 
     @Override
-    public Boolean isDuplicate(Subscription subscription) {
-        return repository.existsByUserIdAndToken(subscription.getUserId(), subscription.getToken());
+    public Boolean checkDeviceDuplicate(Device device) {
+        return repository.existsByDevice(new EmbeddedDevice(device));
     }
 }

--- a/src/main/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapper.java
+++ b/src/main/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapper.java
@@ -22,7 +22,7 @@ public class FirebaseMessageMapper {
 
     private Message mapToFirebaseMessage(PushMessage message) {
         return Message.builder()
-                .setToken(message.getToken())
+                .setToken(message.getDeviceToken())
                 .setNotification(Notification.builder()
                         .setTitle(message.getTitle())
                         .setBody(message.getContent())

--- a/src/main/java/online/bottler/notification/adapter/out/push/FirebasePushAdapter.java
+++ b/src/main/java/online/bottler/notification/adapter/out/push/FirebasePushAdapter.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import online.bottler.notification.application.PushNotificationPort;
+import online.bottler.notification.application.port.PushNotificationPort;
 import online.bottler.notification.domain.PushMessages;
 
 @Slf4j

--- a/src/main/java/online/bottler/notification/application/NotificationService.java
+++ b/src/main/java/online/bottler/notification/application/NotificationService.java
@@ -2,6 +2,7 @@ package online.bottler.notification.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import online.bottler.notification.application.port.PushNotificationPort;
 import online.bottler.notification.application.request.RecommendNotificationCommand;
 import online.bottler.notification.application.response.NotificationResponse;
 import online.bottler.notification.application.response.UnreadNotificationResponse;

--- a/src/main/java/online/bottler/notification/application/SubscriptionService.java
+++ b/src/main/java/online/bottler/notification/application/SubscriptionService.java
@@ -5,6 +5,7 @@ import online.bottler.global.exception.ApplicationException;
 import online.bottler.notification.application.response.SubscriptionResponse;
 import online.bottler.notification.application.port.SubscriptionUseCase;
 import online.bottler.notification.application.port.SubscriptionPersistencePort;
+import online.bottler.notification.domain.Device;
 import online.bottler.notification.domain.Subscription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +17,11 @@ public class SubscriptionService implements SubscriptionUseCase {
 
     @Transactional
     public SubscriptionResponse subscribe(Long userId, String token) {
-        Subscription subscribe = Subscription.create(userId, token);
-        if (subscriptionPersistencePort.isDuplicate(subscribe)) {
+        Subscription subscription = Subscription.create(userId, token);
+        if (subscriptionPersistencePort.checkDeviceDuplicate(subscription.getDevice())) {
             throw new ApplicationException("해당 기기는 이미 알림이 허용되어 있습니다.");
         }
-        Subscription save = subscriptionPersistencePort.save(subscribe);
+        Subscription save = subscriptionPersistencePort.save(subscription);
         return SubscriptionResponse.from(save);
     }
 
@@ -31,6 +32,6 @@ public class SubscriptionService implements SubscriptionUseCase {
 
     @Transactional
     public void unsubscribe(String token) {
-        subscriptionPersistencePort.deleteByToken(token);
+        subscriptionPersistencePort.deleteByDevice(new Device(token));
     }
 }

--- a/src/main/java/online/bottler/notification/application/port/PushNotificationPort.java
+++ b/src/main/java/online/bottler/notification/application/port/PushNotificationPort.java
@@ -1,4 +1,4 @@
-package online.bottler.notification.application;
+package online.bottler.notification.application.port;
 
 import online.bottler.notification.domain.PushMessages;
 

--- a/src/main/java/online/bottler/notification/application/port/SubscriptionPersistencePort.java
+++ b/src/main/java/online/bottler/notification/application/port/SubscriptionPersistencePort.java
@@ -1,5 +1,6 @@
 package online.bottler.notification.application.port;
 
+import online.bottler.notification.domain.Device;
 import online.bottler.notification.domain.Subscription;
 import online.bottler.notification.domain.Subscriptions;
 
@@ -12,7 +13,7 @@ public interface SubscriptionPersistencePort {
 
     void deleteAllByUserId(Long userId);
 
-    void deleteByToken(String token);
+    void deleteByDevice(Device device);
 
-    Boolean isDuplicate(Subscription subscription);
+    Boolean checkDeviceDuplicate(Device device);
 }

--- a/src/main/java/online/bottler/notification/domain/Device.java
+++ b/src/main/java/online/bottler/notification/domain/Device.java
@@ -1,0 +1,26 @@
+package online.bottler.notification.domain;
+
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class Device {
+    private final String token;
+
+    public Device(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Device device = (Device) o;
+        return Objects.equals(token, device.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(token);
+    }
+}

--- a/src/main/java/online/bottler/notification/domain/PushMessage.java
+++ b/src/main/java/online/bottler/notification/domain/PushMessage.java
@@ -6,9 +6,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class PushMessage {
-    private String token;
+    private Device device;
 
     private String title;
 
     private String content;
+
+    public String getDeviceToken() {
+        return device.getToken();
+    }
 }

--- a/src/main/java/online/bottler/notification/domain/Subscription.java
+++ b/src/main/java/online/bottler/notification/domain/Subscription.java
@@ -10,18 +10,18 @@ public class Subscription {
 
     private Long userId;
 
-    private String token;
+    private Device device;
 
     public static Subscription create(Long userId, String token) {
         return Subscription.builder()
                 .userId(userId)
-                .token(token)
+                .device(new Device(token))
                 .build();
     }
 
     public PushMessage makeMessage(NotificationType type) {
         return PushMessage.builder()
-                .token(token)
+                .device(device)
                 .title(type.getTitle())
                 .content(type.getContent())
                 .build();

--- a/src/test/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapterTest.java
@@ -3,6 +3,7 @@ package online.bottler.notification.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import online.bottler.notification.domain.Device;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ class SubscriptionPersistenceAdapterTest {
 
         // then
         assertThat(save.getUserId()).isEqualTo(1L);
-        assertThat(save.getToken()).isEqualTo("token");
+        assertThat(save.getDevice()).isEqualTo(new Device("token"));
         assertThat(save.getId()).isNotNull();
     }
 
@@ -110,13 +111,14 @@ class SubscriptionPersistenceAdapterTest {
     void deleteByToken() {
         // given
         String token = "token1";
+        Device device = new Device("token1");
         Subscription subscription1 = Subscription.create(1L, token);
         Subscription subscription2 = Subscription.create(1L, "token2");
         subscriptionPersistenceAdapter.save(subscription1);
         subscriptionPersistenceAdapter.save(subscription2);
 
         // when
-        subscriptionPersistenceAdapter.deleteByToken(token);
+        subscriptionPersistenceAdapter.deleteByDevice(device);
 
         // then
         Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(1L);
@@ -127,14 +129,14 @@ class SubscriptionPersistenceAdapterTest {
 
     @DisplayName("이미 구독된 유저의 기기라면, true를 반환한다.")
     @Test
-    void isDuplicateWithDuplicateSubscription() {
+    void checkDeviceDuplicateWithDuplicateSubscription() {
         // given
         Subscription subscription = Subscription.create(1L, "token");
         Subscription duplicateSubscription = Subscription.create(1L, "token");
         subscriptionPersistenceAdapter.save(subscription);
 
         // when
-        Boolean result = subscriptionPersistenceAdapter.isDuplicate(duplicateSubscription);
+        Boolean result = subscriptionPersistenceAdapter.checkDeviceDuplicate(duplicateSubscription.getDevice());
 
         // then
         assertThat(result).isTrue();
@@ -142,14 +144,14 @@ class SubscriptionPersistenceAdapterTest {
 
     @DisplayName("저장되지 않은 구독 정보라면, false를 반환한다.")
     @Test
-    void isDuplicate() {
+    void checkDeviceDuplicate() {
         // given
         Subscription subscription = Subscription.create(1L, "token1");
         Subscription notDuplicateSubscription = Subscription.create(1L, "token2");
         subscriptionPersistenceAdapter.save(subscription);
 
         // when
-        Boolean result = subscriptionPersistenceAdapter.isDuplicate(notDuplicateSubscription);
+        Boolean result = subscriptionPersistenceAdapter.checkDeviceDuplicate(notDuplicateSubscription.getDevice());
 
         // then
         assertThat(result).isFalse();

--- a/src/test/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapperTest.java
+++ b/src/test/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapperTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 import com.google.firebase.messaging.Message;
 import java.util.List;
 
+import online.bottler.notification.domain.Device;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +45,7 @@ class FirebaseMessageMapperTest {
 
     private PushMessage createPushMessage(String token, String title, String content) {
         return PushMessage.builder()
-                .token(token)
+                .device(new Device(token))
                 .title(title)
                 .content(content)
                 .build();

--- a/src/test/java/online/bottler/notification/application/NotificationServiceTest.java
+++ b/src/test/java/online/bottler/notification/application/NotificationServiceTest.java
@@ -1,6 +1,7 @@
 package online.bottler.notification.application;
 
 import online.bottler.global.exception.DomainException;
+import online.bottler.notification.application.port.PushNotificationPort;
 import online.bottler.notification.application.request.RecommendNotificationCommand;
 import online.bottler.notification.application.response.NotificationResponse;
 import online.bottler.notification.application.response.UnreadNotificationResponse;

--- a/src/test/java/online/bottler/notification/application/SubscriptionServiceTest.java
+++ b/src/test/java/online/bottler/notification/application/SubscriptionServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import online.bottler.notification.application.port.SubscriptionPersistencePort;
+import online.bottler.notification.domain.Device;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +62,6 @@ public class SubscriptionServiceTest {
         subscriptionService.unsubscribe(token);
 
         // THEN
-        verify(subscriptionRepository, times(1)).deleteByToken(token);
+        verify(subscriptionRepository, times(1)).deleteByDevice(new Device(token));
     }
 }

--- a/src/test/java/online/bottler/notification/domain/SubscriptionTest.java
+++ b/src/test/java/online/bottler/notification/domain/SubscriptionTest.java
@@ -21,7 +21,7 @@ public class SubscriptionTest {
 
         // then
         assertThat(subscription.getUserId()).isEqualTo(1L);
-        assertThat(subscription.getToken()).isEqualTo("token");
+        assertThat(subscription.getDevice()).isEqualTo(new Device(token));
     }
 
     @DisplayName("알림을 보낼 메시지를 생성한다.")
@@ -36,7 +36,7 @@ public class SubscriptionTest {
         PushMessage pushMessage = subscription.makeMessage(NEW_LETTER);
 
         // then
-        assertThat(pushMessage.getToken()).isEqualTo(token);
+        assertThat(pushMessage.getDevice()).isEqualTo(new Device(token));
         assertThat(pushMessage.getTitle()).isEqualTo(NEW_LETTER.getTitle());
         assertThat(pushMessage.getContent()).isEqualTo(NEW_LETTER.getContent());
     }


### PR DESCRIPTION
## 📢 기능 설명 
필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #32 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 디바이스 정보를 캡슐화하는 Device 도메인 객체가 도입되었습니다.

- **기능 개선**
    - 기존에 토큰 문자열로 처리하던 구독, 중복 확인, 삭제 등의 로직이 Device 객체 기반으로 변경되었습니다.
    - 구독, 푸시 메시지, 구독 엔티티 등 여러 도메인 및 서비스 클래스에서 Device 객체를 사용하도록 개선되었습니다.

- **버그 수정**
    - 관련 테스트 코드가 Device 객체 사용에 맞게 수정되었습니다.

- **문서화/정리**
    - 일부 import 및 패키지 선언이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->