### PR TITLE
[Refactor/#36] ComplaintFacade를 통한 도메인 결합 분리

### DIFF
--- a/src/main/java/online/bottler/complaint/adapter/in/ComplaintController.java
+++ b/src/main/java/online/bottler/complaint/adapter/in/ComplaintController.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import online.bottler.auth.CustomUserDetails;
+import online.bottler.complaint.application.ComplaintFacade;
 import online.bottler.complaint.application.ComplaintResponse;
-import online.bottler.complaint.application.port.ComplaintUseCase;
 import online.bottler.global.response.ApiResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,14 +19,14 @@ import static online.bottler.complaint.domain.ComplaintType.*;
 @RequiredArgsConstructor
 @Tag(name = "신고 API", description = "로그인 사용자만 가능")
 public class ComplaintController {
-    private final ComplaintUseCase complaintUseCase;
+    private final ComplaintFacade complaintFacade;
 
     @Operation(summary = "키워드 편지 신고", description = "신고하는 편지 ID와 신고 사유를 등록합니다.")
     @PostMapping("/letters/{letterId}/complaint")
     public ApiResponse<ComplaintResponse> complainKeywordLetter(@PathVariable Long letterId,
                                                                 @RequestBody ComplaintRequest complaintRequest,
                                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        ComplaintResponse response = complaintUseCase.complain(complaintRequest.toCommand(KEYWORD_LETTER, letterId, customUserDetails.getUserId()));
+        ComplaintResponse response = complaintFacade.complain(complaintRequest.toCommand(KEYWORD_LETTER, letterId, customUserDetails.getUserId()));
         return ApiResponse.onCreateSuccess(response);
     }
 
@@ -35,7 +35,7 @@ public class ComplaintController {
     public ApiResponse<ComplaintResponse> complainMapLetter(@PathVariable Long letterId,
                                                             @RequestBody ComplaintRequest complaintRequest,
                                                             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        ComplaintResponse response = complaintUseCase.complain(complaintRequest.toCommand(MAP_LETTER, letterId, customUserDetails.getUserId()));
+        ComplaintResponse response = complaintFacade.complain(complaintRequest.toCommand(MAP_LETTER, letterId, customUserDetails.getUserId()));
         return ApiResponse.onCreateSuccess(response);
     }
 
@@ -44,7 +44,7 @@ public class ComplaintController {
     public ApiResponse<ComplaintResponse> complainMapReplyLetter(@PathVariable Long replyLetterId,
                                                                  @RequestBody ComplaintRequest complaintRequest,
                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        ComplaintResponse response = complaintUseCase.complain(complaintRequest.toCommand(MAP_REPLY_LETTER, replyLetterId, customUserDetails.getUserId()));
+        ComplaintResponse response = complaintFacade.complain(complaintRequest.toCommand(MAP_REPLY_LETTER, replyLetterId, customUserDetails.getUserId()));
         return ApiResponse.onCreateSuccess(response);
     }
 
@@ -53,7 +53,7 @@ public class ComplaintController {
     public ApiResponse<ComplaintResponse> complainKeywordReplyLetter(@PathVariable Long replyLetterId,
                                                                      @RequestBody ComplaintRequest complaintRequest,
                                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        ComplaintResponse response = complaintUseCase.complain(complaintRequest.toCommand(KEYWORD_REPLY_LETTER, replyLetterId, customUserDetails.getUserId()));
+        ComplaintResponse response = complaintFacade.complain(complaintRequest.toCommand(KEYWORD_REPLY_LETTER, replyLetterId, customUserDetails.getUserId()));
         return ApiResponse.onCreateSuccess(response);
     }
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintJpaRepository.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintJpaRepository.java
@@ -1,9 +1,12 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import online.bottler.complaint.adapter.out.persistence.entity.KeywordComplaintEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeywordComplaintJpaRepository extends JpaRepository<KeywordComplaintEntity, Long> {
     List<KeywordComplaintEntity> findByLetterId(Long letterId);
+
+    Optional<KeywordComplaintEntity> findByLetterIdAndReporterId(Long letterId, Long reporterId);
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintPersistenceAdapter.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintPersistenceAdapter.java
@@ -1,12 +1,13 @@
 package online.bottler.complaint.adapter.out.persistence;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import online.bottler.complaint.adapter.out.persistence.entity.KeywordComplaintEntity;
 import online.bottler.complaint.application.port.KeywordComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.Complaints;
-import online.bottler.complaint.adapter.out.persistence.entity.KeywordComplaintEntity;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,5 +24,11 @@ public class KeywordComplaintPersistenceAdapter implements KeywordComplaintPersi
         return Complaints.from(repository.findByLetterId(letterId)
                 .stream().map(KeywordComplaintEntity::toDomain)
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Optional<Complaint> findByLetterIdAndReporterId(Long letterId, Long reporterId) {
+        return repository.findByLetterIdAndReporterId(letterId, reporterId)
+                .map(KeywordComplaintEntity::toDomain);
     }
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintJpaRepository.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintJpaRepository.java
@@ -1,9 +1,12 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import online.bottler.complaint.adapter.out.persistence.entity.KeywordReplyComplaintEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeywordReplyComplaintJpaRepository extends JpaRepository<KeywordReplyComplaintEntity, Long> {
     List<KeywordReplyComplaintEntity> findByLetterId(Long letterId);
+
+    Optional<KeywordReplyComplaintEntity> findByLetterIdAndReporterId(Long letterId, Long reporterId);
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintPersistenceAdapter.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintPersistenceAdapter.java
@@ -1,13 +1,14 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import online.bottler.complaint.adapter.out.persistence.entity.KeywordReplyComplaintEntity;
 import online.bottler.complaint.application.port.KeywordReplyComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.Complaints;
-import online.bottler.complaint.adapter.out.persistence.entity.KeywordReplyComplaintEntity;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,5 +26,11 @@ public class KeywordReplyComplaintPersistenceAdapter implements KeywordReplyComp
         return Complaints.from(entities.stream()
                 .map(KeywordReplyComplaintEntity::toDomain)
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Optional<Complaint> findByLetterIdAndReporterId(Long letterId, Long reporterId) {
+        return repository.findByLetterIdAndReporterId(letterId, reporterId)
+                .map(KeywordReplyComplaintEntity::toDomain);
     }
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/MapComplaintJpaRepository.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/MapComplaintJpaRepository.java
@@ -1,9 +1,12 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import online.bottler.complaint.adapter.out.persistence.entity.MapComplaintEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MapComplaintJpaRepository extends JpaRepository<MapComplaintEntity, Long> {
     List<MapComplaintEntity> findByLetterId(Long letterId);
+
+    Optional<MapComplaintEntity> findByLetterIdAndReporterId(Long letterId, Long reporterId);
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/MapComplaintPersistenceAdapter.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/MapComplaintPersistenceAdapter.java
@@ -1,13 +1,14 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import online.bottler.complaint.adapter.out.persistence.entity.MapComplaintEntity;
 import online.bottler.complaint.application.port.MapComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.Complaints;
-import online.bottler.complaint.adapter.out.persistence.entity.MapComplaintEntity;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,5 +26,11 @@ public class MapComplaintPersistenceAdapter implements MapComplaintPersistencePo
         return Complaints.from(entities.stream()
                 .map(MapComplaintEntity::toDomain)
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Optional<Complaint> findByLetterIdAndReporterId(Long letterId, Long reporterId) {
+        return jpaRepository.findByLetterIdAndReporterId(letterId, reporterId)
+                .map(MapComplaintEntity::toDomain);
     }
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintJpaRepository.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintJpaRepository.java
@@ -1,9 +1,12 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import online.bottler.complaint.adapter.out.persistence.entity.MapReplyComplaintEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MapReplyComplaintJpaRepository extends JpaRepository<MapReplyComplaintEntity, Long> {
     List<MapReplyComplaintEntity> findByLetterId(Long letterId);
+
+    Optional<MapReplyComplaintEntity> findByLetterIdAndReporterId(Long letterId, Long reporterId);
 }

--- a/src/main/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintPersistenceAdapter.java
+++ b/src/main/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintPersistenceAdapter.java
@@ -1,13 +1,14 @@
 package online.bottler.complaint.adapter.out.persistence;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import online.bottler.complaint.adapter.out.persistence.entity.MapReplyComplaintEntity;
 import online.bottler.complaint.application.port.MapReplyComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.Complaints;
-import online.bottler.complaint.adapter.out.persistence.entity.MapReplyComplaintEntity;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,5 +26,11 @@ public class MapReplyComplaintPersistenceAdapter implements MapReplyComplaintPer
         return Complaints.from(entities.stream()
                 .map(MapReplyComplaintEntity::toDomain)
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Optional<Complaint> findByLetterIdAndReporterId(Long letterId, Long reporterId) {
+        return repository.findByLetterIdAndReporterId(letterId, reporterId)
+                .map(MapReplyComplaintEntity::toDomain);
     }
 }

--- a/src/main/java/online/bottler/complaint/application/ComplaintFacade.java
+++ b/src/main/java/online/bottler/complaint/application/ComplaintFacade.java
@@ -1,0 +1,50 @@
+package online.bottler.complaint.application;
+
+import lombok.RequiredArgsConstructor;
+import online.bottler.complaint.application.port.ComplaintUseCase;
+import online.bottler.complaint.domain.ComplaintType;
+import online.bottler.complaint.domain.Complaints;
+import online.bottler.letter.application.port.in.BlockLetterUseCase;
+import online.bottler.letter.application.port.in.BlockReplyLetterUseCase;
+import online.bottler.mapletter.application.BlockMapLetterType;
+import online.bottler.mapletter.application.port.in.MapLetterUseCase;
+import online.bottler.notification.application.port.NotificationUseCase;
+import online.bottler.user.application.port.in.UserUseCase;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ComplaintFacade {
+    private final ComplaintUseCase complaintUseCase;
+    private final NotificationUseCase notificationUseCase;
+    private final BlockLetterUseCase blockLetterUseCase;
+    private final BlockReplyLetterUseCase blockReplyLetterUseCase;
+    private final MapLetterUseCase mapLetterUseCase;
+    private final UserUseCase userUseCase;
+
+    @Transactional
+    public ComplaintResponse complain(ComplaintCommand complaintCommand) {
+        ComplaintResponse complaintResponse = complaintUseCase.complain(complaintCommand);
+        if (complaintUseCase.needWarning(complaintCommand.type(), complaintCommand.letterId())) {
+            sendWarningToWriter(complaintCommand.type(), complaintCommand.letterId());
+        }
+        return complaintResponse;
+    }
+
+    private void sendWarningToWriter(ComplaintType type, Long letterId) {
+        Long writerId = blockLetter(type, letterId);
+        notificationUseCase.sendWarningNotification(writerId);
+        userUseCase.updateWarningCount(writerId);
+    }
+
+    private Long blockLetter(ComplaintType type, Long letterId) {
+        return switch (type) {
+            case MAP_LETTER -> mapLetterUseCase.letterBlock(BlockMapLetterType.MAP_LETTER, letterId);
+            case MAP_REPLY_LETTER -> mapLetterUseCase.letterBlock(BlockMapLetterType.REPLY, letterId);
+            case KEYWORD_LETTER -> blockLetterUseCase.softBlock(letterId);
+            case KEYWORD_REPLY_LETTER -> blockReplyLetterUseCase.softBlock(letterId);
+        };
+    }
+
+}

--- a/src/main/java/online/bottler/complaint/application/ComplaintService.java
+++ b/src/main/java/online/bottler/complaint/application/ComplaintService.java
@@ -1,16 +1,17 @@
 package online.bottler.complaint.application;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import online.bottler.complaint.application.port.*;
+import online.bottler.complaint.application.port.ComplaintPersistencePort;
+import online.bottler.complaint.application.port.ComplaintUseCase;
+import online.bottler.complaint.application.port.KeywordComplaintPersistencePort;
+import online.bottler.complaint.application.port.KeywordReplyComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapReplyComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.ComplaintType;
 import online.bottler.complaint.domain.Complaints;
-import online.bottler.letter.application.port.in.BlockLetterUseCase;
-import online.bottler.letter.application.port.in.BlockReplyLetterUseCase;
-import online.bottler.mapletter.application.BlockMapLetterType;
-import online.bottler.mapletter.application.port.in.MapLetterUseCase;
-import online.bottler.notification.application.port.NotificationUseCase;
-import online.bottler.user.application.port.in.UserUseCase;
+import online.bottler.global.exception.ApplicationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,55 +23,38 @@ public class ComplaintService implements ComplaintUseCase {
     private final KeywordReplyComplaintPersistencePort keywordReplyComplaintPersistencePort;
     private final MapReplyComplaintPersistencePort mapReplyComplaintPersistencePort;
 
-    private final NotificationUseCase notificationUseCase;
-    private final BlockLetterUseCase blockLetterUseCase;
-    private final BlockReplyLetterUseCase blockReplyLetterUseCase;
-    private final MapLetterUseCase mapLetterUseCase;
-    private final UserUseCase userUseCase;
-
     @Override
     @Transactional
     public ComplaintResponse complain(ComplaintCommand complaintCommand) {
         Complaint newComplaint = complaintCommand.toComplaint();
-        Complaints existingComplaints = findExistingComplaints(complaintCommand.type(), complaintCommand.letterId());
-        existingComplaints.add(newComplaint);
-        if (existingComplaints.needWarning()) {
-            sendWarningToWriter(complaintCommand.type(), complaintCommand.letterId());
-        }
-        return ComplaintResponse.from(saveComplaint(newComplaint, complaintCommand.type()));
+        ComplaintPersistencePort persistencePort = getPersistencePort(complaintCommand.type());
+        validateDuplicateComplaint(persistencePort, complaintCommand);
+        return ComplaintResponse.from(persistencePort.save(newComplaint));
     }
 
-    private Complaints findExistingComplaints(ComplaintType type, Long letterId) {
-        ComplaintPersistencePort repository = getRepositoryByType(type);
-        return repository.findByLetterId(letterId);
+    @Override
+    @Transactional(readOnly = true)
+    public boolean needWarning(ComplaintType type, Long letterId) {
+        ComplaintPersistencePort persistencePort = getPersistencePort(type);
+        Complaints complaints = persistencePort.findByLetterId(letterId);
+        return complaints.needWarning();
     }
 
-    private void sendWarningToWriter(ComplaintType type, Long letterId) {
-        Long writerId = blockLetter(type, letterId);
-        notificationUseCase.sendWarningNotification(writerId);
-        userUseCase.updateWarningCount(writerId);
-    }
-
-    private Long blockLetter(ComplaintType type, Long letterId) {
-        return switch (type) {
-            case MAP_LETTER -> mapLetterUseCase.letterBlock(BlockMapLetterType.MAP_LETTER, letterId);
-            case MAP_REPLY_LETTER -> mapLetterUseCase.letterBlock(BlockMapLetterType.REPLY, letterId);
-            case KEYWORD_LETTER -> blockLetterUseCase.softBlock(letterId);
-            case KEYWORD_REPLY_LETTER -> blockReplyLetterUseCase.softBlock(letterId);
-        };
-    }
-
-    private Complaint saveComplaint(Complaint complaint, ComplaintType type) {
-        ComplaintPersistencePort repository = getRepositoryByType(type);
-        return repository.save(complaint);
-    }
-
-    private ComplaintPersistencePort getRepositoryByType(ComplaintType type) {
+    private ComplaintPersistencePort getPersistencePort(ComplaintType type) {
         return switch (type) {
             case MAP_LETTER -> mapComplaintPersistencePort;
             case MAP_REPLY_LETTER -> mapReplyComplaintPersistencePort;
             case KEYWORD_LETTER -> keywordComplaintPersistencePort;
             case KEYWORD_REPLY_LETTER -> keywordReplyComplaintPersistencePort;
         };
+    }
+
+    private void validateDuplicateComplaint(ComplaintPersistencePort persistencePort,
+                                            ComplaintCommand complaintCommand) {
+        Optional<Complaint> complaint = persistencePort.findByLetterIdAndReporterId(
+                complaintCommand.letterId(), complaintCommand.reporterId());
+        if (complaint.isPresent()) {
+            throw new ApplicationException("이미 신고한 편지입니다.");
+        }
     }
 }

--- a/src/main/java/online/bottler/complaint/application/port/ComplaintPersistencePort.java
+++ b/src/main/java/online/bottler/complaint/application/port/ComplaintPersistencePort.java
@@ -3,8 +3,12 @@ package online.bottler.complaint.application.port;
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.Complaints;
 
+import java.util.Optional;
+
 public interface ComplaintPersistencePort {
     Complaint save(Complaint complaint);
 
     Complaints findByLetterId(Long letterId);
+
+    Optional<Complaint> findByLetterIdAndReporterId(Long letterId, Long reporterId);
 }

--- a/src/main/java/online/bottler/complaint/application/port/ComplaintUseCase.java
+++ b/src/main/java/online/bottler/complaint/application/port/ComplaintUseCase.java
@@ -2,9 +2,11 @@ package online.bottler.complaint.application.port;
 
 import online.bottler.complaint.application.ComplaintCommand;
 import online.bottler.complaint.application.ComplaintResponse;
+import online.bottler.complaint.domain.ComplaintType;
 
 public interface ComplaintUseCase {
 
     ComplaintResponse complain(ComplaintCommand complaintCommand);
 
+    boolean needWarning(ComplaintType complaintType, Long letterId);
 }

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionEntity.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import online.bottler.notification.domain.Subscription;
 
 @Entity
-@Table(name = "subscription")
+@Table(name = "subscription", indexes = @Index(name = "user_token_idx", columnList = "userId, token"))
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/test/java/online/bottler/IdGenerator.java
+++ b/src/test/java/online/bottler/IdGenerator.java
@@ -1,0 +1,12 @@
+package online.bottler;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdGenerator {
+    private long currentId = 1;
+
+    public synchronized long generateId() {
+        return currentId++;
+    }
+}

--- a/src/test/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/complaint/adapter/out/persistence/KeywordComplaintPersistenceAdapterTest.java
@@ -5,14 +5,14 @@ import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
-
+import online.bottler.IdGenerator;
+import online.bottler.complaint.domain.Complaint;
+import online.bottler.complaint.domain.Complaints;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import online.bottler.complaint.domain.Complaint;
-import online.bottler.complaint.domain.Complaints;
 
 @DisplayName("키워드 신고 리포지토리 테스트")
 @SpringBootTest
@@ -20,12 +20,16 @@ import online.bottler.complaint.domain.Complaints;
 public class KeywordComplaintPersistenceAdapterTest {
     @Autowired
     private KeywordComplaintPersistenceAdapter keywordComplaintPersistenceAdapter;
+    @Autowired
+    private IdGenerator idGenerator;
 
     @DisplayName("새로운 신고를 저장한다.")
     @Test
     void save() {
         // given
-        Complaint complaint = Complaint.create(1L, 1L, "욕설 사용");
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        Complaint complaint = Complaint.create(letterId, reporterId, "욕설 사용");
 
         // when
         keywordComplaintPersistenceAdapter.save(complaint);
@@ -39,28 +43,32 @@ public class KeywordComplaintPersistenceAdapterTest {
     @Test
     void findByLetterId() {
         // given
-        keywordComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        keywordComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = keywordComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = keywordComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         assertThat(find.getComplaints()).hasSize(1)
                 .extracting("letterId", "reporterId", "description")
-                .contains(tuple(1L, 1L, "설명"));
+                .contains(tuple(letterId, reporterId, "설명"));
     }
 
     @Test
     @DisplayName("편지 ID로 조회한 신고 리스트는 MutableList이어야 한다.")
     public void findByLetterIdWithMutable() {
         // GIVEN
-        keywordComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        keywordComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // WHEN
-        Complaints find = keywordComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = keywordComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // THEN
         List<Complaint> complaints = find.getComplaints();
-        assertDoesNotThrow((() -> complaints.add(Complaint.create(2L, 1L, "설명"))));
+        assertDoesNotThrow((() -> complaints.add(Complaint.create(letterId, idGenerator.generateId(), "설명"))));
     }
 }

--- a/src/test/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/complaint/adapter/out/persistence/KeywordReplyComplaintPersistenceAdapterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
 
+import online.bottler.IdGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,17 +17,20 @@ import online.bottler.complaint.domain.Complaints;
 
 @DisplayName("키워드 답장 편지 리포지토리 테스트")
 @SpringBootTest
-@Transactional
 class KeywordReplyComplaintPersistenceAdapterTest {
 
     @Autowired
     private KeywordReplyComplaintPersistenceAdapter keywordReplyComplaintPersistenceAdapter;
+    @Autowired
+    private IdGenerator idGenerator;
 
     @DisplayName("새로운 신고를 저장한다.")
     @Test
     void save() {
         // given
-        Complaint complaint = Complaint.create(1L, 1L, "욕설 사용");
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        Complaint complaint = Complaint.create(letterId, reporterId, "욕설 사용");
 
         // when
         keywordReplyComplaintPersistenceAdapter.save(complaint);
@@ -40,28 +44,32 @@ class KeywordReplyComplaintPersistenceAdapterTest {
     @Test
     void findByLetterId() {
         // given
-        keywordReplyComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        keywordReplyComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = keywordReplyComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = keywordReplyComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         assertThat(find.getComplaints()).hasSize(1)
                 .extracting("letterId", "reporterId", "description")
-                .contains(tuple(1L, 1L, "설명"));
+                .contains(tuple(letterId, reporterId, "설명"));
     }
 
     @Test
     @DisplayName("편지 ID로 조회한 신고 리스트는 MutableList이어야 한다.")
     public void findByLetterIdWithMutable() {
         // given
-        keywordReplyComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        keywordReplyComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = keywordReplyComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = keywordReplyComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         List<Complaint> complaints = find.getComplaints();
-        assertDoesNotThrow((() -> complaints.add(Complaint.create(2L, 1L, "설명"))));
+        assertDoesNotThrow((() -> complaints.add(Complaint.create(letterId, idGenerator.generateId(), "설명"))));
     }
 }

--- a/src/test/java/online/bottler/complaint/adapter/out/persistence/MapComplaintPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/complaint/adapter/out/persistence/MapComplaintPersistenceAdapterTest.java
@@ -5,27 +5,29 @@ import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
-
+import online.bottler.IdGenerator;
+import online.bottler.complaint.domain.Complaint;
+import online.bottler.complaint.domain.Complaints;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-import online.bottler.complaint.domain.Complaint;
-import online.bottler.complaint.domain.Complaints;
 
 @DisplayName("지도 편지 리포지토리 테스트")
 @SpringBootTest
-@Transactional
 public class MapComplaintPersistenceAdapterTest {
     @Autowired
     private MapComplaintPersistenceAdapter mapComplaintPersistenceAdapter;
+    @Autowired
+    private IdGenerator idGenerator;
 
     @DisplayName("새로운 신고를 저장한다.")
     @Test
     void save() {
         // given
-        Complaint complaint = Complaint.create(1L, 1L, "욕설 사용");
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        Complaint complaint = Complaint.create(letterId, reporterId, "욕설 사용");
 
         // when
         mapComplaintPersistenceAdapter.save(complaint);
@@ -39,28 +41,33 @@ public class MapComplaintPersistenceAdapterTest {
     @Test
     void findByLetterId() {
         // given
-        mapComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        mapComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = mapComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = mapComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         assertThat(find.getComplaints()).hasSize(1)
                 .extracting("letterId", "reporterId", "description")
-                .contains(tuple(1L, 1L, "설명"));
+                .contains(tuple(letterId, reporterId, "설명"));
     }
 
     @Test
     @DisplayName("편지 ID로 조회한 신고 리스트는 MutableList이어야 한다.")
     public void findByLetterIdWithMutable() {
         // GIVEN
-        mapComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        mapComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // WHEN
-        Complaints find = mapComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = mapComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // THEN
         List<Complaint> complaints = find.getComplaints();
-        assertDoesNotThrow((() -> complaints.add(Complaint.create(2L, 1L, "설명"))));
+        assertDoesNotThrow(
+                (() -> complaints.add(Complaint.create(idGenerator.generateId(), idGenerator.generateId(), "설명"))));
     }
 }

--- a/src/test/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/complaint/adapter/out/persistence/MapReplyComplaintPersistenceAdapterTest.java
@@ -5,29 +5,31 @@ import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
-
+import online.bottler.IdGenerator;
+import online.bottler.complaint.domain.Complaint;
+import online.bottler.complaint.domain.Complaints;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-import online.bottler.complaint.domain.Complaint;
-import online.bottler.complaint.domain.Complaints;
 
 
 @DisplayName("지도 답장 편지 리포지토리 테스트")
 @SpringBootTest
-@Transactional
 class MapReplyComplaintPersistenceAdapterTest {
 
     @Autowired
     private MapReplyComplaintPersistenceAdapter mapReplyComplaintPersistenceAdapter;
+    @Autowired
+    private IdGenerator idGenerator;
 
     @DisplayName("새로운 신고를 저장한다.")
     @Test
     void save() {
         // given
-        Complaint complaint = Complaint.create(1L, 1L, "욕설 사용");
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        Complaint complaint = Complaint.create(letterId, reporterId, "욕설 사용");
 
         // when
         mapReplyComplaintPersistenceAdapter.save(complaint);
@@ -41,28 +43,32 @@ class MapReplyComplaintPersistenceAdapterTest {
     @Test
     void findByLetterId() {
         // given
-        mapReplyComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        mapReplyComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = mapReplyComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = mapReplyComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         assertThat(find.getComplaints()).hasSize(1)
                 .extracting("letterId", "reporterId", "description")
-                .contains(tuple(1L, 1L, "설명"));
+                .contains(tuple(letterId, reporterId, "설명"));
     }
 
     @Test
     @DisplayName("편지 ID로 조회한 신고 리스트는 MutableList이어야 한다.")
     public void findByLetterIdWithMutable() {
         // given
-        mapReplyComplaintPersistenceAdapter.save(Complaint.create(1L, 1L, "설명"));
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        mapReplyComplaintPersistenceAdapter.save(Complaint.create(letterId, reporterId, "설명"));
 
         // when
-        Complaints find = mapReplyComplaintPersistenceAdapter.findByLetterId(1L);
+        Complaints find = mapReplyComplaintPersistenceAdapter.findByLetterId(letterId);
 
         // then
         List<Complaint> complaints = find.getComplaints();
-        assertDoesNotThrow((() -> complaints.add(Complaint.create(2L, 1L, "설명"))));
+        assertDoesNotThrow((() -> complaints.add(Complaint.create(letterId, idGenerator.generateId(), "설명"))));
     }
 }

--- a/src/test/java/online/bottler/complaint/application/ComplaintFacadeTest.java
+++ b/src/test/java/online/bottler/complaint/application/ComplaintFacadeTest.java
@@ -1,0 +1,271 @@
+package online.bottler.complaint.application;
+
+import static online.bottler.complaint.domain.ComplaintType.KEYWORD_LETTER;
+import static online.bottler.complaint.domain.ComplaintType.KEYWORD_REPLY_LETTER;
+import static online.bottler.complaint.domain.ComplaintType.MAP_LETTER;
+import static online.bottler.complaint.domain.ComplaintType.MAP_REPLY_LETTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Collection;
+import java.util.List;
+import online.bottler.IdGenerator;
+import online.bottler.complaint.application.port.KeywordComplaintPersistencePort;
+import online.bottler.complaint.application.port.KeywordReplyComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapReplyComplaintPersistencePort;
+import online.bottler.complaint.domain.Complaint;
+import online.bottler.global.exception.ApplicationException;
+import online.bottler.letter.application.LetterWithKeywordsService;
+import online.bottler.letter.application.ReplyLetterService;
+import online.bottler.mapletter.application.BlockMapLetterType;
+import online.bottler.mapletter.application.MapLetterService;
+import online.bottler.notification.application.NotificationService;
+import online.bottler.user.application.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+@DisplayName("신고 서비스 테스트")
+public class ComplaintFacadeTest {
+    @Autowired
+    private ComplaintFacade complaintFacade;
+    @Autowired
+    private KeywordComplaintPersistencePort keywordComplaintPersistencePort;
+    @Autowired
+    private KeywordReplyComplaintPersistencePort keywordReplyComplaintPersistencePort;
+    @Autowired
+    private MapComplaintPersistencePort mapComplaintPersistencePort;
+    @Autowired
+    private MapReplyComplaintPersistencePort mapReplyComplaintPersistencePort;
+    @Autowired
+    private IdGenerator idGenerator;
+    @MockBean
+    private NotificationService notificationUseCase;
+    @MockBean
+    private LetterWithKeywordsService blockLetterUseCase;
+    @MockBean
+    private ReplyLetterService blockReplyLetterUseCase;
+    @MockBean
+    private MapLetterService mapLetterUseCase;
+    @MockBean
+    private UserService userUseCase;
+
+    @DisplayName("키워드 편지 시나리오")
+    @TestFactory
+    Collection<DynamicTest> complainKeywordLetter() {
+        // given
+        long letterId = idGenerator.generateId();
+        long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(KEYWORD_LETTER, letterId, reporterId, "욕설 사용");
+
+        return List.of(
+                dynamicTest("키워드 편지를 신고한다.", () -> {
+                    // when
+                    ComplaintResponse response = complaintFacade.complain(complaintCommand);
+
+                    // then
+                    assertThat(response.id()).isNotNull();
+                    assertThat(response.description()).isEqualTo("욕설 사용");
+                }),
+                dynamicTest("한 유저가 같은 키워드 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                    // when then
+                    assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
+                            .isInstanceOf(ApplicationException.class);
+                })
+        );
+    }
+
+    @DisplayName("키워드 답장 편지 시나리오")
+    @TestFactory
+    Collection<DynamicTest> complainKeywordReplyLetter() {
+        // given
+        long letterId = idGenerator.generateId();
+        long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(KEYWORD_REPLY_LETTER, letterId, reporterId, "욕설 사용");
+        return List.of(
+                dynamicTest("키워드 답장 편지를 신고한다.", () -> {
+                    // when
+                    ComplaintResponse response = complaintFacade.complain(complaintCommand);
+
+                    // then
+                    assertThat(response.id()).isNotNull();
+                    assertThat(response.description()).isEqualTo("욕설 사용");
+                }),
+                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                    // when then
+                    assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
+                            .isInstanceOf(ApplicationException.class);
+                })
+        );
+    }
+
+    @DisplayName("지도 편지 시나리오")
+    @TestFactory
+    Collection<DynamicTest> complainMapLetter() {
+        // given
+        long letterId = idGenerator.generateId();
+        long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(MAP_LETTER, letterId, reporterId, "욕설 사용");
+
+        return List.of(
+                dynamicTest("지도 편지를 신고한다.", () -> {
+                    // when
+                    ComplaintResponse response = complaintFacade.complain(complaintCommand);
+
+                    // then
+                    assertThat(response.id()).isNotNull();
+                    assertThat(response.description()).isEqualTo("욕설 사용");
+                }),
+                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                    // when then
+                    assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
+                            .isInstanceOf(ApplicationException.class);
+                })
+        );
+    }
+
+    @DisplayName("지도 편지 시나리오")
+    @TestFactory
+    Collection<DynamicTest> complainMapReplyLetter() {
+        // given
+        long letterId = idGenerator.generateId();
+        long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(MAP_REPLY_LETTER, letterId, reporterId, "욕설 사용");
+
+        return List.of(
+                dynamicTest("지도 편지를 신고한다.", () -> {
+                    // when
+                    ComplaintResponse response = complaintFacade.complain(complaintCommand);
+
+                    // then
+                    assertThat(response.id()).isNotNull();
+                    assertThat(response.description()).isEqualTo("욕설 사용");
+                }),
+                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                    // when then
+                    assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
+                            .isInstanceOf(ApplicationException.class);
+                })
+        );
+    }
+
+    @DisplayName("경고 알림이 필요한 경우, 작성자의 경고 횟수를 증가시킨다.")
+    @Test
+    void needWarningWithUserService() {
+        // given
+        Long letterId = idGenerator.generateId();
+        Long reporterA = idGenerator.generateId();
+        Long reporterB = idGenerator.generateId();
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, reporterA, "욕설 사용"));
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, reporterB, "욕설 사용"));
+        Long writerId = idGenerator.generateId();
+
+        given(blockLetterUseCase.softBlock(letterId))
+                .willReturn(writerId);
+
+        // when
+        Long reporterC = idGenerator.generateId();
+        complaintFacade.complain(new ComplaintCommand(KEYWORD_LETTER, letterId, reporterC, "욕설 사용"));
+
+        // then
+        Mockito.verify(userUseCase, Mockito.times(1))
+                .updateWarningCount(writerId);
+    }
+
+    @DisplayName("경고 알림이 필요한 경우, 작성자에게 알림을 전송한다.")
+    @Test
+    void needWarningWithNotificationService() {
+        // given
+        Long letterId = idGenerator.generateId();
+        Long reporterA = idGenerator.generateId();
+        Long reporterB = idGenerator.generateId();
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, reporterA, "욕설 사용"));
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, reporterB, "욕설 사용"));
+        Long writerId = idGenerator.generateId();
+
+        given(blockLetterUseCase.softBlock(letterId))
+                .willReturn(writerId);
+
+        // when
+        Long reporterC = idGenerator.generateId();
+        complaintFacade.complain(new ComplaintCommand(KEYWORD_LETTER, letterId, reporterC, "욕설 사용"));
+
+        // then
+        Mockito.verify(notificationUseCase, Mockito.times(1))
+                .sendWarningNotification(writerId);
+    }
+
+    @DisplayName("지도 편지 경고가 필요할 경우, 해당 지도 편지는 블락된다.")
+    @Test
+    void blockMapLetter() {
+        // given
+        Long letterId = idGenerator.generateId();
+        mapComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        mapComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // when
+        complaintFacade.complain(new ComplaintCommand(MAP_LETTER, letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // then
+        Mockito.verify(mapLetterUseCase, Mockito.times(1))
+                .letterBlock(BlockMapLetterType.MAP_LETTER, letterId);
+    }
+
+    @DisplayName("지도 답장 편지 경고가 필요할 경우, 해당 지도 답장 편지는 블락된다.")
+    @Test
+    void blockMapReplyLetter() {
+        // given
+        Long letterId = idGenerator.generateId();
+        mapReplyComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        mapReplyComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // when
+        complaintFacade.complain(new ComplaintCommand(MAP_REPLY_LETTER, letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // then
+        Mockito.verify(mapLetterUseCase, Mockito.times(1))
+                .letterBlock(BlockMapLetterType.REPLY, letterId);
+    }
+
+    @DisplayName("키워드 편지 경고가 필요할 경우, 해당 키워드 편지는 블락된다.")
+    @Test
+    void blockKeywordLetter() {
+        // given
+        Long letterId = idGenerator.generateId();
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        keywordComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // when
+        complaintFacade.complain(new ComplaintCommand(KEYWORD_LETTER, letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // then
+        Mockito.verify(blockLetterUseCase, Mockito.times(1))
+                .softBlock(letterId);
+    }
+
+    @DisplayName("지도 답장 편지 경고가 필요할 경우, 해당 지도 답장 편지는 블락된다.")
+    @Test
+    void blockKeywordReplyLetter() {
+        // given
+        Long letterId = idGenerator.generateId();
+        keywordReplyComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        keywordReplyComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // when
+        complaintFacade.complain(
+                new ComplaintCommand(KEYWORD_REPLY_LETTER, letterId, idGenerator.generateId(), "욕설 사용"));
+
+        // then
+        Mockito.verify(blockReplyLetterUseCase, Mockito.times(1))
+                .softBlock(letterId);
+    }
+}

--- a/src/test/java/online/bottler/complaint/application/ComplaintFacadeTest.java
+++ b/src/test/java/online/bottler/complaint/application/ComplaintFacadeTest.java
@@ -125,7 +125,7 @@ public class ComplaintFacadeTest {
                     assertThat(response.id()).isNotNull();
                     assertThat(response.description()).isEqualTo("욕설 사용");
                 }),
-                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                dynamicTest("한 유저가 같은 지도 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
                     // when then
                     assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
                             .isInstanceOf(ApplicationException.class);
@@ -133,7 +133,7 @@ public class ComplaintFacadeTest {
         );
     }
 
-    @DisplayName("지도 편지 시나리오")
+    @DisplayName("지도 답장 편지 시나리오")
     @TestFactory
     Collection<DynamicTest> complainMapReplyLetter() {
         // given
@@ -150,7 +150,7 @@ public class ComplaintFacadeTest {
                     assertThat(response.id()).isNotNull();
                     assertThat(response.description()).isEqualTo("욕설 사용");
                 }),
-                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
+                dynamicTest("한 유저가 같은 지도 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
                     // when then
                     assertThatThrownBy(() -> complaintFacade.complain(complaintCommand))
                             .isInstanceOf(ApplicationException.class);

--- a/src/test/java/online/bottler/complaint/application/ComplaintServiceTest.java
+++ b/src/test/java/online/bottler/complaint/application/ComplaintServiceTest.java
@@ -1,172 +1,111 @@
 package online.bottler.complaint.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import online.bottler.IdGenerator;
+import online.bottler.complaint.application.port.ComplaintPersistencePort;
 import online.bottler.complaint.application.port.KeywordComplaintPersistencePort;
+import online.bottler.complaint.application.port.KeywordReplyComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapComplaintPersistencePort;
+import online.bottler.complaint.application.port.MapReplyComplaintPersistencePort;
 import online.bottler.complaint.domain.Complaint;
-import online.bottler.global.exception.DomainException;
-import online.bottler.letter.application.LetterService;
-import online.bottler.notification.application.NotificationService;
-import online.bottler.user.application.UserService;
+import online.bottler.complaint.domain.ComplaintType;
+import online.bottler.global.exception.ApplicationException;
+import online.bottler.notification.domain.NotificationType;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
-
-import static online.bottler.complaint.domain.ComplaintType.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.DynamicTest.dynamicTest;
-import static org.mockito.BDDMockito.given;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 @SpringBootTest
-@DisplayName("신고 서비스 테스트")
-@Transactional
-public class ComplaintServiceTest {
+class ComplaintServiceTest {
+
     @Autowired
     private ComplaintService complaintService;
-    @Autowired
+    @SpyBean
     private KeywordComplaintPersistencePort keywordComplaintPersistencePort;
+    @SpyBean
+    private MapComplaintPersistencePort mapComplaintPersistencePort;
+    @SpyBean
+    private KeywordReplyComplaintPersistencePort keywordReplyComplaintPersistencePort;
+    @SpyBean
+    private MapReplyComplaintPersistencePort mapReplyComplaintPersistencePort;
+    @Autowired
+    private IdGenerator idGenerator;
 
-    @MockBean
-    private NotificationService notificationService;
-    @MockBean
-    private LetterService letterService;
-    @MockBean
-    private UserService userService;
-
-    @DisplayName("키워드 편지 시나리오")
-    @TestFactory
-    Collection<DynamicTest> complainKeywordLetter() {
-        // given
-        ComplaintCommand complaintCommand = new ComplaintCommand(KEYWORD_LETTER, 1L, 1L, "욕설 사용");
-
-        return List.of(
-                dynamicTest("키워드 편지를 신고한다.", () -> {
-                    // when
-                    ComplaintResponse response = complaintService.complain(complaintCommand);
-
-                    // then
-                    assertThat(response.id()).isNotNull();
-                    assertThat(response.description()).isEqualTo("욕설 사용");
-                }),
-                dynamicTest("한 유저가 같은 키워드 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
-                    // when then
-                    assertThatThrownBy(() -> complaintService.complain(complaintCommand))
-                            .isInstanceOf(DomainException.class);
-                })
-        );
-    }
-
-    @DisplayName("키워드 답장 편지 시나리오")
-    @TestFactory
-    Collection<DynamicTest> complainKeywordReplyLetter() {
-        // given
-        ComplaintCommand complaintCommand = new ComplaintCommand(KEYWORD_REPLY_LETTER, 1L, 1L, "욕설 사용");
-        return List.of(
-                dynamicTest("키워드 답장 편지를 신고한다.", () -> {
-                    // when
-                    ComplaintResponse response = complaintService.complain(complaintCommand);
-
-                    // then
-                    assertThat(response.id()).isNotNull();
-                    assertThat(response.description()).isEqualTo("욕설 사용");
-                }),
-                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
-                    // when then
-                    assertThatThrownBy(() -> complaintService.complain(complaintCommand))
-                            .isInstanceOf(DomainException.class);
-                })
-        );
-    }
-
-    @DisplayName("지도 편지 시나리오")
-    @TestFactory
-    Collection<DynamicTest> complainMapLetter() {
-        // given
-        ComplaintCommand complaintCommand = new ComplaintCommand(MAP_LETTER, 1L, 1L, "욕설 사용");
-
-        return List.of(
-                dynamicTest("지도 편지를 신고한다.", () -> {
-                    // when
-                    ComplaintResponse response = complaintService.complain(complaintCommand);
-
-                    // then
-                    assertThat(response.id()).isNotNull();
-                    assertThat(response.description()).isEqualTo("욕설 사용");
-                }),
-                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
-                    // when then
-                    assertThatThrownBy(() -> complaintService.complain(complaintCommand))
-                            .isInstanceOf(DomainException.class);
-                })
-        );
-    }
-
-    @DisplayName("지도 편지 시나리오")
-    @TestFactory
-    Collection<DynamicTest> complainMapReplyLetter() {
-        // given
-        ComplaintCommand complaintCommand = new ComplaintCommand(MAP_REPLY_LETTER, 1L, 1L, "욕설 사용");
-
-        return List.of(
-                dynamicTest("지도 편지를 신고한다.", () -> {
-                    // when
-                    ComplaintResponse response = complaintService.complain(complaintCommand);
-
-                    // then
-                    assertThat(response.id()).isNotNull();
-                    assertThat(response.description()).isEqualTo("욕설 사용");
-                }),
-                dynamicTest("한 유저가 같은 키워드 답장 편지를 2회 이상 신고 시도할 경우, 예외가 발생한다.", () -> {
-                    // when then
-                    assertThatThrownBy(() -> complaintService.complain(complaintCommand))
-                            .isInstanceOf(DomainException.class);
-                })
-        );
-    }
-
-    @DisplayName("경고 알림이 필요한 경우, 작성자의 경고 횟수를 증가시킨다.")
+    @DisplayName("편지를 신고한다.")
     @Test
-    void needWarningWithUserService() {
+    void complain() {
         // given
-        keywordComplaintPersistencePort.save(Complaint.create(1L, 1L, "욕설 사용"));
-        keywordComplaintPersistencePort.save(Complaint.create(1L, 2L, "욕설 사용"));
-        Long writerId = 5L;
-
-        given(letterService.softBlockLetter(1L))
-                .willReturn(writerId);
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(ComplaintType.MAP_LETTER, letterId, reporterId,
+                "욕설 사용");
 
         // when
-        complaintService.complain(new ComplaintCommand(KEYWORD_LETTER, 1L, 3L, "욕설 사용"));
+        ComplaintResponse complaintResponse = complaintService.complain(complaintCommand);
 
         // then
-        Mockito.verify(userService, Mockito.times(1))
-                .updateWarningCount(writerId);
+        Optional<Complaint> find = mapComplaintPersistencePort.findByLetterIdAndReporterId(letterId, reporterId);
+        assertThat(find).isPresent();
+        assertThat(complaintResponse.id()).isEqualTo(find.get().getId());
     }
 
-    @DisplayName("경고 알림이 필요한 경우, 작성자에게 알림을 전송한다.")
+    @DisplayName("사용자가 이미 해당 편지를 신고한 경우, 예외가 발생한다.")
     @Test
-    void needWarningWithNotificationService() {
-        // given
-        keywordComplaintPersistencePort.save(Complaint.create(1L, 1L, "욕설 사용"));
-        keywordComplaintPersistencePort.save(Complaint.create(1L, 2L, "욕설 사용"));
-        Long writerId = 5L;
+    void duplicateComplaint() {
+        // given®
+        Long letterId = idGenerator.generateId();
+        long reporterId = idGenerator.generateId();
+        mapComplaintPersistencePort.save(Complaint.create(letterId, reporterId, "욕설 사용"));
 
-        given(letterService.softBlockLetter(1L))
-                .willReturn(writerId);
+        // when then
+        assertThatThrownBy(() -> complaintService.complain(
+                new ComplaintCommand(ComplaintType.MAP_LETTER, letterId, reporterId, "욕설 사용")))
+                .isInstanceOf(ApplicationException.class);
+    }
+
+    @DisplayName("편지 신고가 3회 쌓이면, 경고가 필요하다.")
+    @Test
+    void needWarning() {
+        // given
+        Long letterId = idGenerator.generateId();
+        mapComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        mapComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
+        mapComplaintPersistencePort.save(Complaint.create(letterId, idGenerator.generateId(), "욕설 사용"));
 
         // when
-        complaintService.complain(new ComplaintCommand(KEYWORD_LETTER, 1L, 3L, "욕설 사용"));
+        boolean needWarning = complaintService.needWarning(ComplaintType.MAP_LETTER, letterId);
 
         // then
-        Mockito.verify(notificationService, Mockito.times(1))
-                .sendWarningNotification(writerId);
+        assertThat(needWarning).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({"MAP_LETTER", "MAP_REPLY_LETTER", "KEYWORD_LETTER", "KEYWORD_REPLY_LETTER"})
+    @DisplayName("편지 종류에 따라 적절한 포트를 사용한다.")
+    public void isLetterNotification(ComplaintType complaintType) {
+        // given
+        Long letterId = idGenerator.generateId();
+        Long reporterId = idGenerator.generateId();
+        ComplaintCommand complaintCommand = new ComplaintCommand(complaintType, letterId, reporterId, "욕설 사용");
+
+        // when
+        complaintService.complain(complaintCommand);
+
+        // then
+        switch (complaintType) {
+            case MAP_LETTER -> Mockito.verify(mapComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            case MAP_REPLY_LETTER -> Mockito.verify(mapReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            case KEYWORD_LETTER -> Mockito.verify(keywordComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            case KEYWORD_REPLY_LETTER -> Mockito.verify(keywordReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            default -> throw new IllegalArgumentException("Unknown complaint type: " + complaintType);
+        }
     }
 }

--- a/src/test/java/online/bottler/complaint/application/ComplaintServiceTest.java
+++ b/src/test/java/online/bottler/complaint/application/ComplaintServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 import online.bottler.IdGenerator;
-import online.bottler.complaint.application.port.ComplaintPersistencePort;
 import online.bottler.complaint.application.port.KeywordComplaintPersistencePort;
 import online.bottler.complaint.application.port.KeywordReplyComplaintPersistencePort;
 import online.bottler.complaint.application.port.MapComplaintPersistencePort;
@@ -13,7 +12,6 @@ import online.bottler.complaint.application.port.MapReplyComplaintPersistencePor
 import online.bottler.complaint.domain.Complaint;
 import online.bottler.complaint.domain.ComplaintType;
 import online.bottler.global.exception.ApplicationException;
-import online.bottler.notification.domain.NotificationType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,7 +58,7 @@ class ComplaintServiceTest {
     @DisplayName("사용자가 이미 해당 편지를 신고한 경우, 예외가 발생한다.")
     @Test
     void duplicateComplaint() {
-        // given®
+        // given
         Long letterId = idGenerator.generateId();
         long reporterId = idGenerator.generateId();
         mapComplaintPersistencePort.save(Complaint.create(letterId, reporterId, "욕설 사용"));
@@ -102,9 +100,11 @@ class ComplaintServiceTest {
         // then
         switch (complaintType) {
             case MAP_LETTER -> Mockito.verify(mapComplaintPersistencePort).save(Mockito.any(Complaint.class));
-            case MAP_REPLY_LETTER -> Mockito.verify(mapReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            case MAP_REPLY_LETTER ->
+                    Mockito.verify(mapReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
             case KEYWORD_LETTER -> Mockito.verify(keywordComplaintPersistencePort).save(Mockito.any(Complaint.class));
-            case KEYWORD_REPLY_LETTER -> Mockito.verify(keywordReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
+            case KEYWORD_REPLY_LETTER ->
+                    Mockito.verify(keywordReplyComplaintPersistencePort).save(Mockito.any(Complaint.class));
             default -> throw new IllegalArgumentException("Unknown complaint type: " + complaintType);
         }
     }


### PR DESCRIPTION
## 📢 기능 설명 
필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #36 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 다양한 유형의 민원(키워드/지도/댓글 등)에 대해 신고자와 편지 ID로 민원을 조회할 수 있는 기능이 추가되었습니다.
    - 중복 신고 방지 로직이 도입되어 동일 사용자가 동일 편지에 대해 여러 번 신고할 수 없습니다.
    - 민원 처리 시 경고가 필요한 경우, 자동으로 해당 편지를 차단하고 작성자에게 경고 알림이 발송되며, 경고 횟수가 갱신됩니다.
    - 민원 처리 로직이 별도의 계층으로 분리되어 관리됩니다.

- **버그 수정**
    - 중복된 신고가 발생하지 않도록 검증이 강화되었습니다.

- **테스트**
    - ID를 동적으로 생성하는 유틸리티가 도입되어 테스트의 신뢰성이 향상되었습니다.
    - 민원 처리 및 경고, 차단, 알림 발송 등 다양한 시나리오에 대한 통합 테스트가 추가되었습니다.
    - 테스트 코드에서 하드코딩된 ID 사용을 제거하고, 동적으로 생성된 ID를 사용하도록 개선하였습니다.

- **리팩터링**
    - 민원 처리 로직이 단순화되고, 경고 및 차단, 알림 관련 코드가 별도의 계층으로 분리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->