### PR TITLE
[Feature/#43] Subscription 캐시 계층 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
     // test dotenv
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
     testImplementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    implementation 'org.testcontainers:testcontainers-bom:1.20.2'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:testcontainers'
 }
 
 tasks.named('test') {

--- a/src/main/java/online/bottler/config/RedisConfig.java
+++ b/src/main/java/online/bottler/config/RedisConfig.java
@@ -9,6 +9,7 @@ import online.bottler.notification.adapter.out.push.SseMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,6 +19,7 @@ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@Profile("!test")
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
@@ -74,5 +76,16 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> subscriptionTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
     }
 }

--- a/src/main/java/online/bottler/notification/adapter/in/web/NotificationController.java
+++ b/src/main/java/online/bottler/notification/adapter/in/web/NotificationController.java
@@ -74,8 +74,9 @@ public class NotificationController {
 
     @Operation(summary = "기기 알림 비허용", description = "특정 토큰을 삭제합니다.")
     @DeleteMapping("/subscribe")
-    public ApiResponse<String> unsubscribe(@RequestBody UnsubscriptionRequest unsubscriptionRequest) {
-        subscriptionUseCase.unsubscribe(unsubscriptionRequest.token());
+    public ApiResponse<String> unsubscribe(@RequestBody UnsubscriptionRequest unsubscriptionRequest,
+                                           @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        subscriptionUseCase.unsubscribe(customUserDetails.getUserId(), unsubscriptionRequest.token());
         return ApiResponse.onDeleteSuccess("삭제 성공");
     }
 }

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/CacheRepository.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/CacheRepository.java
@@ -1,0 +1,64 @@
+package online.bottler.notification.adapter.out.persistence;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.bottler.notification.domain.Device;
+import online.bottler.notification.domain.Subscription;
+import online.bottler.notification.domain.Subscriptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CacheRepository {
+    private final RedisTemplate<String, String> subscriptionTemplate;
+    private final String REDIS_KEY_FORMAT = "subscription:%d";
+
+    public void save(Subscription subscription) {
+        String key = getKey(subscription.getUserId());
+        subscriptionTemplate.opsForList().rightPush(key, subscription.getDevice().getToken());
+        updateTtl(key);
+    }
+
+    public void save(Subscriptions subscriptions) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+        for (Subscription subscription : subscriptions.getSubscriptions()) {
+            save(subscription);
+        }
+    }
+
+    public Subscriptions findByUserId(Long userId) {
+        List<Subscription> subscriptions = new ArrayList<>();
+        String key = getKey(userId);
+        List<String> tokens = subscriptionTemplate.opsForList().range(key, 0, -1);
+        if (tokens != null) {
+            for (String token : tokens) {
+                subscriptions.add(Subscription.create(userId, token));
+            }
+            updateTtl(key);
+        }
+        return Subscriptions.from(subscriptions);
+    }
+
+    public void deleteByDevice(Long userId, Device device) {
+        String key = getKey(userId);
+        subscriptionTemplate.opsForList().remove(key, 0, device.getToken());
+    }
+
+    public void deleteAllByUserId(Long userId) {
+        String key = getKey(userId);
+        subscriptionTemplate.delete(key);
+    }
+
+    private String getKey(Long userId) {
+        return String.format(REDIS_KEY_FORMAT, userId);
+    }
+
+    private void updateTtl(String key) {
+        subscriptionTemplate.expire(key, Duration.ofHours(6));
+    }
+}

--- a/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapter.java
+++ b/src/main/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package online.bottler.notification.adapter.out.persistence;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.bottler.notification.application.port.SubscriptionPersistencePort;
 import online.bottler.notification.domain.Device;
@@ -7,25 +8,29 @@ import online.bottler.notification.domain.Subscription;
 import online.bottler.notification.domain.Subscriptions;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 @RequiredArgsConstructor
 public class SubscriptionPersistenceAdapter implements SubscriptionPersistencePort {
     private final SubscriptionJpaRepository repository;
+    private final CacheRepository cacheRepository;
 
     @Override
     public Subscription save(Subscription subscription) {
-        SubscriptionEntity save = repository.save(SubscriptionEntity.from(subscription));
-        return save.toDomain();
+        cacheRepository.save(subscription);
+        return repository.save(SubscriptionEntity.from(subscription))
+                .toDomain();
     }
 
     @Override
     public Subscriptions findByUserId(Long userId) {
-        List<Subscription> subscriptions = repository.findByUserId(userId).stream()
-                .map(SubscriptionEntity::toDomain)
-                .toList();
-        return Subscriptions.from(subscriptions);
+        Subscriptions subscriptions = cacheRepository.findByUserId(userId);
+        if (subscriptions.isEmpty()) {
+            subscriptions = Subscriptions.from(repository.findByUserId(userId).stream()
+                    .map(SubscriptionEntity::toDomain)
+                    .toList());
+            cacheRepository.save(subscriptions);
+        }
+        return subscriptions;
     }
 
     @Override
@@ -38,11 +43,13 @@ public class SubscriptionPersistenceAdapter implements SubscriptionPersistencePo
 
     @Override
     public void deleteAllByUserId(Long userId) {
+        cacheRepository.deleteAllByUserId(userId);
         repository.deleteAllByUserId(userId);
     }
 
     @Override
-    public void deleteByDevice(Device device) {
+    public void deleteByDevice(Long userId, Device device) {
+        cacheRepository.deleteByDevice(userId, device);
         repository.deleteByDevice(new EmbeddedDevice(device));
     }
 

--- a/src/main/java/online/bottler/notification/application/SubscriptionService.java
+++ b/src/main/java/online/bottler/notification/application/SubscriptionService.java
@@ -31,7 +31,7 @@ public class SubscriptionService implements SubscriptionUseCase {
     }
 
     @Transactional
-    public void unsubscribe(String token) {
-        subscriptionPersistencePort.deleteByDevice(new Device(token));
+    public void unsubscribe(Long userId, String token) {
+        subscriptionPersistencePort.deleteByDevice(userId, new Device(token));
     }
 }

--- a/src/main/java/online/bottler/notification/application/port/SubscriptionPersistencePort.java
+++ b/src/main/java/online/bottler/notification/application/port/SubscriptionPersistencePort.java
@@ -13,7 +13,7 @@ public interface SubscriptionPersistencePort {
 
     void deleteAllByUserId(Long userId);
 
-    void deleteByDevice(Device device);
+    void deleteByDevice(Long userId, Device device);
 
     Boolean checkDeviceDuplicate(Device device);
 }

--- a/src/main/java/online/bottler/notification/application/port/SubscriptionUseCase.java
+++ b/src/main/java/online/bottler/notification/application/port/SubscriptionUseCase.java
@@ -8,6 +8,6 @@ public interface SubscriptionUseCase {
 
     void unsubscribeAll(Long userId);
 
-    void unsubscribe(String token);
+    void unsubscribe(Long userId, String token);
 
 }

--- a/src/main/java/online/bottler/notification/domain/Subscriptions.java
+++ b/src/main/java/online/bottler/notification/domain/Subscriptions.java
@@ -27,4 +27,8 @@ public class Subscriptions {
     public Boolean isPushEnabled() {
         return subscriptions != null && !subscriptions.isEmpty();
     }
+
+    public boolean isEmpty() {
+        return subscriptions == null || subscriptions.isEmpty();
+    }
 }

--- a/src/test/java/online/bottler/RedisTestContainersConfig.java
+++ b/src/test/java/online/bottler/RedisTestContainersConfig.java
@@ -1,0 +1,105 @@
+package online.bottler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import java.util.List;
+import online.bottler.notification.adapter.out.push.SseMessage;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@TestConfiguration
+@Testcontainers
+public class RedisTestContainersConfig {
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    private static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.4.1-alpine3.20")
+            .withExposedPorts(REDIS_PORT)
+            .waitingFor(Wait.forListeningPort())
+            .withStartupTimeout(Duration.ofSeconds(60));
+
+    static {
+        redisContainer.start();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(
+                redisContainer.getHost(),
+                redisContainer.getMappedPort(REDIS_PORT)
+        );
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, DefaultTyping.NON_FINAL);
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        template.setEnableTransactionSupport(true);
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, List<Long>> redisListTemplate() {
+        RedisTemplate<String, List<Long>> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, DefaultTyping.NON_FINAL);
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, SseMessage> messageTemplate() {
+        RedisTemplate<String, SseMessage> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(SseMessage.class));
+        return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> subscriptionTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/test/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapterTest.java
+++ b/src/test/java/online/bottler/notification/adapter/out/persistence/SubscriptionPersistenceAdapterTest.java
@@ -3,19 +3,24 @@ package online.bottler.notification.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import online.bottler.IdGenerator;
+import online.bottler.RedisTestContainersConfig;
 import online.bottler.notification.domain.Device;
+import online.bottler.notification.domain.Subscription;
+import online.bottler.notification.domain.Subscriptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
-import online.bottler.notification.domain.Subscription;
-import online.bottler.notification.domain.Subscriptions;
 
 @SpringBootTest
 @Transactional
+@Import(RedisTestContainersConfig.class)
 class SubscriptionPersistenceAdapterTest {
-
+    @Autowired
+    private IdGenerator idGenerator;
     @Autowired
     private SubscriptionPersistenceAdapter subscriptionPersistenceAdapter;
 
@@ -38,21 +43,21 @@ class SubscriptionPersistenceAdapterTest {
     @Test
     void findByUserId() {
         // given
-        Long userId = 1L;
+        Long userId = idGenerator.generateId();
         Subscription subscription1 = Subscription.create(userId, "token1");
         Subscription subscription2 = Subscription.create(userId, "token2");
         subscriptionPersistenceAdapter.save(subscription1);
         subscriptionPersistenceAdapter.save(subscription2);
 
         // when
-        Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(1L);
+        Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(userId);
 
         // then
         assertThat(subscriptions.getSubscriptions()).hasSize(2)
                 .extracting("userId", "device")
                 .containsExactlyInAnyOrder(
-                        tuple(1L, new Device("token1")),
-                        tuple(1L, new Device("token2"))
+                        tuple(userId, new Device("token1")),
+                        tuple(userId, new Device("token2"))
                 );
     }
 
@@ -60,7 +65,7 @@ class SubscriptionPersistenceAdapterTest {
     @Test
     void findByUserIdWithoutSubscription() {
         // given
-        Long userId = 1L;
+        Long userId = idGenerator.generateId();
 
         // when
         Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(userId);
@@ -73,8 +78,10 @@ class SubscriptionPersistenceAdapterTest {
     @Test
     void findAll() {
         // given
-        Subscription subscription1 = Subscription.create(1L, "token1");
-        Subscription subscription2 = Subscription.create(2L, "token2");
+        long userId1 = idGenerator.generateId();
+        Subscription subscription1 = Subscription.create(userId1, "token1");
+        long userId2 = idGenerator.generateId();
+        Subscription subscription2 = Subscription.create(userId2, "token2");
         subscriptionPersistenceAdapter.save(subscription1);
         subscriptionPersistenceAdapter.save(subscription2);
 
@@ -85,8 +92,8 @@ class SubscriptionPersistenceAdapterTest {
         assertThat(subscriptions.getSubscriptions()).hasSize(2)
                 .extracting("userId", "device")
                 .containsExactlyInAnyOrder(
-                        tuple(1L, new Device("token1")),
-                        tuple(2L, new Device("token2"))
+                        tuple(userId1, new Device("token1")),
+                        tuple(userId2, new Device("token2"))
                 );
     }
 
@@ -94,7 +101,7 @@ class SubscriptionPersistenceAdapterTest {
     @Test
     void deleteAllByUserId() {
         // given
-        Long userId = 1L;
+        Long userId = idGenerator.generateId();
         Subscription subscription = Subscription.create(userId, "token1");
         subscriptionPersistenceAdapter.save(subscription);
 
@@ -112,27 +119,29 @@ class SubscriptionPersistenceAdapterTest {
         // given
         String token = "token1";
         Device device = new Device("token1");
-        Subscription subscription1 = Subscription.create(1L, token);
-        Subscription subscription2 = Subscription.create(1L, "token2");
+        long userId = idGenerator.generateId();
+        Subscription subscription1 = Subscription.create(userId, token);
+        Subscription subscription2 = Subscription.create(userId, "token2");
         subscriptionPersistenceAdapter.save(subscription1);
         subscriptionPersistenceAdapter.save(subscription2);
 
         // when
-        subscriptionPersistenceAdapter.deleteByDevice(device);
+        subscriptionPersistenceAdapter.deleteByDevice(userId, device);
 
         // then
-        Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(1L);
+        Subscriptions subscriptions = subscriptionPersistenceAdapter.findByUserId(userId);
         assertThat(subscriptions.getSubscriptions()).hasSize(1)
                 .extracting("userId", "device")
-                .containsExactlyInAnyOrder(tuple(1L, new Device("token2")));
+                .containsExactlyInAnyOrder(tuple(userId, new Device("token2")));
     }
 
     @DisplayName("이미 구독된 유저의 기기라면, true를 반환한다.")
     @Test
     void checkDeviceDuplicateWithDuplicateSubscription() {
         // given
-        Subscription subscription = Subscription.create(1L, "token");
-        Subscription duplicateSubscription = Subscription.create(1L, "token");
+        long userId = idGenerator.generateId();
+        Subscription subscription = Subscription.create(userId, "token");
+        Subscription duplicateSubscription = Subscription.create(userId, "token");
         subscriptionPersistenceAdapter.save(subscription);
 
         // when
@@ -146,8 +155,9 @@ class SubscriptionPersistenceAdapterTest {
     @Test
     void checkDeviceDuplicate() {
         // given
-        Subscription subscription = Subscription.create(1L, "token1");
-        Subscription notDuplicateSubscription = Subscription.create(1L, "token2");
+        Long userId = idGenerator.generateId();
+        Subscription subscription = Subscription.create(userId, "token1");
+        Subscription notDuplicateSubscription = Subscription.create(userId, "token2");
         subscriptionPersistenceAdapter.save(subscription);
 
         // when

--- a/src/test/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapperTest.java
+++ b/src/test/java/online/bottler/notification/adapter/out/push/FirebaseMessageMapperTest.java
@@ -5,16 +5,18 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import com.google.firebase.messaging.Message;
 import java.util.List;
-
+import online.bottler.RedisTestContainersConfig;
 import online.bottler.notification.domain.Device;
+import online.bottler.notification.domain.PushMessage;
+import online.bottler.notification.domain.PushMessages;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import online.bottler.notification.domain.PushMessage;
-import online.bottler.notification.domain.PushMessages;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(RedisTestContainersConfig.class)
 class FirebaseMessageMapperTest {
 
     @Autowired

--- a/src/test/java/online/bottler/notification/application/NotificationServiceTest.java
+++ b/src/test/java/online/bottler/notification/application/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package online.bottler.notification.application;
 
+import online.bottler.RedisTestContainersConfig;
 import online.bottler.global.exception.DomainException;
 import online.bottler.notification.application.port.PushNotificationPort;
 import online.bottler.notification.application.request.RecommendNotificationCommand;
@@ -16,6 +17,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.verify;
 
 @DisplayName("알림 서비스 테스트")
 @SpringBootTest
+@Import(RedisTestContainersConfig.class)
 public class NotificationServiceTest {
     @Autowired
     private NotificationService notificationService;

--- a/src/test/java/online/bottler/notification/application/SubscriptionServiceTest.java
+++ b/src/test/java/online/bottler/notification/application/SubscriptionServiceTest.java
@@ -59,9 +59,9 @@ public class SubscriptionServiceTest {
         String token = "token";
 
         // WHEN
-        subscriptionService.unsubscribe(token);
+        subscriptionService.unsubscribe(1L, token);
 
         // THEN
-        verify(subscriptionRepository, times(1)).deleteByDevice(new Device(token));
+        verify(subscriptionRepository, times(1)).deleteByDevice(1L, new Device(token));
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 

write through + look aside 패턴을 통한 캐시 전략

## 연결된 issue
close #43 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 구독 정보를 Redis 기반 캐시에 저장하고 조회하는 기능이 추가되었습니다.
  * 구독 정보가 캐시에 없을 경우 DB에서 조회 후 캐시에 저장하도록 개선되었습니다.

* **버그 수정**
  * 구독 해지(구독 취소) 시 사용자 ID와 디바이스 토큰을 함께 전달하여 보다 정확한 구독 해지가 가능해졌습니다.

* **테스트**
  * Redis Testcontainers를 활용한 통합 테스트 환경이 추가되었습니다.
  * 테스트에서 사용자 ID를 동적으로 생성하여 테스트의 신뢰성을 높였습니다.

* **기타**
  * 테스트 및 개발 환경에서의 Redis 설정이 분리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->